### PR TITLE
Fix Kubernetes breaking changes for version v1.24.0

### DIFF
--- a/examples/deployment.yaml
+++ b/examples/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2  # This is a deprecated version
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: example-app
@@ -14,7 +14,7 @@ spec:
         app: example-app
     spec:
       containers:
-      - name: example-app
-        image: nginx:latest
+      - image: nginx:latest
+        name: example-app
         ports:
         - containerPort: 80


### PR DESCRIPTION
Fix Kubernetes breaking changes for version v1.24.0

This commit fixes the following breaking changes:
- /var/folders/hm/64kmddq53j1dmp72_qqpk9gm0000gp/T/tmp_fyc9f_y/examples/deployment.yaml: apps/v1beta2 was removed in Kubernetes v1.16. Use apps/v1 instead.
