### PR TITLE
Fix Kubernetes breaking changes for version v1.24.0

### DIFF
--- a/examples/deployment.yaml
+++ b/examples/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2  # This is a deprecated version
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: example-app
@@ -14,7 +14,7 @@ spec:
         app: example-app
     spec:
       containers:
-      - name: example-app
-        image: nginx:latest
+      - image: nginx:latest
+        name: example-app
         ports:
         - containerPort: 80

--- a/examples/ingress.yaml
+++ b/examples/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1  # This is a deprecated version
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: example-ingress
@@ -8,7 +8,7 @@ spec:
   - host: example.com
     http:
       paths:
-      - path: /
-        backend:
+      - backend:
           serviceName: example-service
           servicePort: 80
+        path: /


### PR DESCRIPTION
Fix Kubernetes breaking changes for version v1.24.0

This commit fixes the following breaking changes:
- /var/folders/hm/64kmddq53j1dmp72_qqpk9gm0000gp/T/tmpe2_fyhf4/examples/deployment.yaml: apps/v1beta2 was removed in Kubernetes v1.16. Use apps/v1 instead.
- /var/folders/hm/64kmddq53j1dmp72_qqpk9gm0000gp/T/tmpe2_fyhf4/examples/ingress.yaml: extensions/v1beta1 was removed in Kubernetes v1.22. Use networking.k8s.io/v1 instead.
